### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ minimal web service; no linting/test support is needed for the workflow.
 
 You can inspect the workflow file at `.github/workflows/daily_status.yml`.
 
+### README auto-update workflow
+A second agentic workflow (`.github/workflows/update-readme.lock.yml`) runs on every push to **main**. It compares recent commits against the current README, detects documentation drift, and opens a pull request with corrections when needed. If the README is already accurate, the workflow takes no action.
+
 ---
 
 **Notes for the demo presentation**


### PR DESCRIPTION
The `update-readme` agentic workflow (`.github/workflows/update-readme.lock.yml`) was added in a recent commit but was not reflected in the README.

**What changed:**
- Added a new section under "Setup & usage" describing the README auto-update workflow: what it does (detects documentation drift on every push to `main`) and where to find it.

No application code or other docs were changed.




> Generated by [Update README](https://github.com/pappupaul/agentic-workflow-t01/actions/runs/22536030738)

<!-- gh-aw-agentic-workflow: Update README, engine: copilot, id: 22536030738, workflow_id: update-readme, run: https://github.com/pappupaul/agentic-workflow-t01/actions/runs/22536030738 -->

<!-- gh-aw-workflow-id: update-readme -->